### PR TITLE
Added list casting for action attribute

### DIFF
--- a/pycfmodel/model/resources/properties/statement.py
+++ b/pycfmodel/model/resources/properties/statement.py
@@ -37,6 +37,9 @@ class Statement(object):
         if not self.action:
             return []
 
+        if type(self.action) != list:
+            self.action = [self.action]
+
         if pattern:
             return [
                 a for a in self.action

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ dev_requires = [
 
 setup(
     name='pycfmodel',
-    version='0.2.10',
+    version='0.2.11',
     description='A python model for CloudFormation scripts',
     author='Skyscanner Product Security',
     author_email='security@skyscanner.net',


### PR DESCRIPTION
Fixed a bug where wildcard_actions method iterated over the string of an IAM policy action instead of a list that was expected. This can happen if a policy is created that does not have more than one action (is a string). This caused very odd regex behavior. I found this bug because I wanted to write a pattern that would match wildcarded actions if there were fewer than 5 characters after the ":" before the wildcard. This would allow the code to have a match if the action was wide open but still allow developers some wildcard flexibility. Essentially what was happening was the regex would only be applied to a single character with the last being "*" if there was one. This made the regex behave almost opposite of how I expected. This issue might be in other parts of the library as well but this the only one I ran into since I just started using this project today.