### PR TITLE
Fix statement wildcard actions (modified)

### DIFF
--- a/pycfmodel/model/resources/properties/statement.py
+++ b/pycfmodel/model/resources/properties/statement.py
@@ -17,8 +17,6 @@ import re
 
 from .principal import PrincipalFactory
 
-import pdb
-
 
 class Statement(object):
 
@@ -36,12 +34,9 @@ class Statement(object):
         return principals_factory.generate_principals(principals)
 
     def wildcard_actions(self, pattern=None):
-        # pdb.set_trace()
         if not self.action:
             return []
 
-        # if type(self.action) != list:
-        #     self.action = [self.action]
         if not isinstance(self.action, list):
             self.action = [self.action]
 

--- a/pycfmodel/model/resources/properties/statement.py
+++ b/pycfmodel/model/resources/properties/statement.py
@@ -17,6 +17,8 @@ import re
 
 from .principal import PrincipalFactory
 
+import pdb
+
 
 class Statement(object):
 
@@ -34,10 +36,13 @@ class Statement(object):
         return principals_factory.generate_principals(principals)
 
     def wildcard_actions(self, pattern=None):
+        # pdb.set_trace()
         if not self.action:
             return []
 
-        if type(self.action) != list:
+        # if type(self.action) != list:
+        #     self.action = [self.action]
+        if not isinstance(self.action, list):
             self.action = [self.action]
 
         if pattern:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ dev_requires = [
 
 setup(
     name='pycfmodel',
-    version='0.2.11',
+    version='0.2.12',
     description='A python model for CloudFormation scripts',
     author='Skyscanner Product Security',
     author_email='security@skyscanner.net',


### PR DESCRIPTION
I should have done this to begin with. I swapped out type for isinstance because if the object type is not a built-in the previous logic will fail. This was causing action lists to become nested lists when this condition happened. After going through the code in more detail to understand what was going on, this also matches the current conventions of code better anyways. I did not bump the version since this is fixing the same issue as before. Let me know if I do need to update the version.