### PR TITLE
Add IAM user resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ inspecting CloudFormation scripts.
 * parameters
 * resources
     * Generic Resource
+    * IAM User
     * IAM Group
     * IAM Managed Policy
-    * IAM role
+    * IAM Role
     * S3 Bucket Policy
     * Security Group Egress
     * Security Group Ingress

--- a/pycfmodel/model/resource_factory.py
+++ b/pycfmodel/model/resource_factory.py
@@ -15,6 +15,7 @@ specific language governing permissions and limitations under the License.
 
 from .resources.generic_resource import GenericResource
 from .resources.iam_group import IAMGroup
+from .resources.iam_user import IAMUser
 from .resources.iam_managed_policy import IAMManagedPolicy
 from .resources.iam_policy import IAMPolicy
 from .resources.iam_role import IAMRole
@@ -34,6 +35,7 @@ class ResourceFactory(object):
         "AWS::S3::BucketPolicy": S3BucketPolicy,
         "AWS::IAM::ManagedPolicy": IAMManagedPolicy,
         "AWS::IAM::Group": IAMGroup,
+        "AWS::IAM::User": IAMUser,
         "AWS::EC2::SecurityGroup": SecurityGroup,
         "AWS::EC2::SecurityGroupEgress": SecurityGroupEgress,
         "AWS::EC2::SecurityGroupIngress": SecurityGroupIngress,

--- a/pycfmodel/model/resources/iam_user.py
+++ b/pycfmodel/model/resources/iam_user.py
@@ -1,0 +1,45 @@
+"""
+Copyright 2018 Skyscanner Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from .resource import Resource
+
+
+class IAMUser(Resource):
+
+    def __init__(self, logical_id, value):
+        """
+        "UserName": String,
+        "ManagedPolicyArns": [ String, ... ],
+        "Path": String,
+        "Policies": [ Policies, ... ]
+        """
+        super().__init__(logical_id, value)
+
+        self.user_name = None
+        self.path = None
+        self.policies = []
+
+        self.policies = self.get_policies(
+            value.get("Properties", {}).get("Policies"),
+        )
+        self.managed_policy_arns = self.get_managed_policy_arns(
+            value.get("Properties", {}).get("ManagedPolicyArns"),
+        )
+        self.set_generic_keys(
+            value.get("Properties", {}),
+            ["Policies", "ManagedPolicyArns"],
+        )
+        self.set_properties(
+            value.get("Properties", {})
+        )

--- a/pycfmodel/model/resources/iam_user.py
+++ b/pycfmodel/model/resources/iam_user.py
@@ -28,13 +28,12 @@ class IAMUser(Resource):
 
         self.user_name = None
         self.path = None
-        self.policies = []
 
         self.policies = self.get_policies(
-            value.get("Properties", {}).get("Policies"),
+            value.get("Properties", []).get("Policies"),
         )
         self.managed_policy_arns = self.get_managed_policy_arns(
-            value.get("Properties", {}).get("ManagedPolicyArns"),
+            value.get("Properties", []).get("ManagedPolicyArns"),
         )
         self.set_generic_keys(
             value.get("Properties", {}),

--- a/pycfmodel/model/resources/iam_user.py
+++ b/pycfmodel/model/resources/iam_user.py
@@ -30,10 +30,10 @@ class IAMUser(Resource):
         self.path = None
 
         self.policies = self.get_policies(
-            value.get("Properties", []).get("Policies"),
+            value.get("Properties", {}).get("Policies", []),
         )
         self.managed_policy_arns = self.get_managed_policy_arns(
-            value.get("Properties", []).get("ManagedPolicyArns"),
+            value.get("Properties", {}).get("ManagedPolicyArns", []),
         )
         self.set_generic_keys(
             value.get("Properties", {}),

--- a/pycfmodel/model/resources/properties/statement.py
+++ b/pycfmodel/model/resources/properties/statement.py
@@ -21,13 +21,17 @@ from .principal import PrincipalFactory
 class Statement(object):
 
     def __init__(self, statement):
-        self.action = statement.get("Action")
+        self.action = statement.get("Action", [])
         self.resource = statement.get("Resource")
         self.principal = self.__parse_principals(statement.get("Principal"))
         self.effect = statement.get("Effect")
         self.condition = statement.get("Condition", {})
         self.not_action = statement.get("NotAction", {})
         self.not_principal = statement.get("NotPrincipal", {})
+        if not isinstance(self.action, list):
+            self.action = [self.action]
+        if not isinstance(self.resource, list):
+            self.resource = [self.resource]
 
     def __parse_principals(self, principals):
         principals_factory = PrincipalFactory()
@@ -36,9 +40,6 @@ class Statement(object):
     def wildcard_actions(self, pattern=None):
         if not self.action:
             return []
-
-        if not isinstance(self.action, list):
-            self.action = [self.action]
 
         if pattern:
             return [

--- a/pycfmodel/model/resources/properties/statement.py
+++ b/pycfmodel/model/resources/properties/statement.py
@@ -22,7 +22,7 @@ class Statement(object):
 
     def __init__(self, statement):
         self.action = statement.get("Action", [])
-        self.resource = statement.get("Resource")
+        self.resource = statement.get("Resource", [])
         self.principal = self.__parse_principals(statement.get("Principal"))
         self.effect = statement.get("Effect")
         self.condition = statement.get("Condition", {})

--- a/pycfmodel/model/resources/resource.py
+++ b/pycfmodel/model/resources/resource.py
@@ -27,6 +27,7 @@ class Resource(object):
         self.logical_id = logical_id
         self.resource_type = value.get("Type")
         self.metadata = {}
+        self.properties = {}
 
     def set_generic_keys(self, properties, exclude_list):
         generic_keys = set(properties.keys()) - set(exclude_list)
@@ -38,6 +39,9 @@ class Resource(object):
 
     def set_metadata(self, metadata):
         self.metadata = metadata
+
+    def set_properties(self, properties):
+        self.properties = properties
 
     def get_policies(self, policies):
         if not policies:
@@ -72,6 +76,11 @@ class Resource(object):
         return self._all_cap_re.sub(r'\1_\2', s1).lower()
 
     def has_hardcoded_credentials(self):
+        if self.resource_type == "AWS::IAM::User" and self.properties:
+            login_profile = self.properties.get("LoginProfile", {})
+            if "Password" in list(login_profile):
+                return True
+
         if not self.metadata or not self.metadata.get("AWS::CloudFormation::Authentication"):
             return False
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ dev_requires = [
 
 setup(
     name='pycfmodel',
-    version='0.3.1',
+    version='0.3.2',
     description='A python model for CloudFormation scripts',
     author='Skyscanner Product Security',
     author_email='security@skyscanner.net',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ dev_requires = [
 
 setup(
     name='pycfmodel',
-    version='0.3.0',
+    version='0.3.1',
     description='A python model for CloudFormation scripts',
     author='Skyscanner Product Security',
     author_email='security@skyscanner.net',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ dev_requires = [
 
 setup(
     name='pycfmodel',
-    version='0.2.12',
+    version='0.3.0',
     description='A python model for CloudFormation scripts',
     author='Skyscanner Product Security',
     author_email='security@skyscanner.net',

--- a/tests/test_iam_user.py
+++ b/tests/test_iam_user.py
@@ -1,0 +1,63 @@
+"""
+Copyright 2018 Skyscanner Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+
+from pycfmodel.model.resources.iam_user import IAMUser
+
+cf_script = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Resources": {
+        "myuser": {
+            "Type": "AWS::IAM::User",
+            "Properties": {
+                "Path": "/",
+                "UserName": "TestUser",
+                "LoginProfile": {"Password": "ThisMyBestP@ssword", "PasswordResetRequired": False},
+                    "Policies": [
+                        {
+                            "PolicyName": "BadPolicy",
+                            "PolicyDocument": {
+                                "Version": "2012-10-17",
+                                "Statement": [
+                                    {
+                                        "Effect": "Allow",
+                                        "Action": [
+                                            "lambda:AddPermission",
+                                            "ssm:SendCommand",
+                                            "kms:Decrypt"
+                                        ],
+                                        "Resource": "*"
+                                    }
+                                ]
+                            }
+                        }
+                ]
+            }
+        }
+    }
+}
+
+
+iam_user = IAMUser("myuser", cf_script["Resources"]["myuser"])
+
+
+def test_policies():
+    assert len(iam_user.policies) == 1
+    policy = iam_user.policies[0]
+    assert policy.policy_name == "BadPolicy"
+
+
+def test_credential_check():
+    assert iam_user.has_hardcoded_credentials()


### PR DESCRIPTION
Added IAM user resource so that I did not have to work with it as a default resource type. You will notice I did add a `set_properties` method. I did this so I could load the IAM user properties specifically to be used for the `has_hardcoded_credentials` check. I wanted to check the `LoginProfile` property and receive a boolean value depending on if credentials were found. I thought this might work nicely with the method you already had. Let me know if you want to change they way this data is loaded. I bumped the version! Not sure if you want to just bump this to `0.3.1`. Technically if someone had automation written using the generic resource for an IAM user the change to a specific resource might break some things. The issue I ran into was with the generic resource the `policies` attribute returned the json loaded policies section of the CF template. Now that IAM user is a real resource the policies attribute will return a list of `pycfmodel.model.resources.properties.policy.Policy` objects. As mentioned let me know if you want me to change something.