### PR TITLE
Add matching principals methods

### DIFF
--- a/pycfmodel/model/resources/properties/policy_document.py
+++ b/pycfmodel/model/resources/properties/policy_document.py
@@ -203,6 +203,22 @@ class PolicyDocument(object):
 
         return wildcard_allowed
 
+    def matching_principals(self, pattern=r"*", effects=["Allow"]):
+        """
+        Find statements which match the given pattern and effect
+
+        If no pattern is specified it will match all principals
+        If no effects are specified it will match statements with the Allow effect
+        """
+
+        matching_statements = []
+
+        for statement in self.statements:
+            if statement.matching_principals(pattern) and statement.effect in effects:
+                matching_statements.append(statement)
+
+        return matching_statements
+
     def nonwhitelisted_allowed_principals(self, whitelist=None):
         """Find non whitelisted allowed principals."""
 

--- a/pycfmodel/model/resources/properties/principal.py
+++ b/pycfmodel/model/resources/properties/principal.py
@@ -40,6 +40,12 @@ class Principal(object):
                 return True
         return False
 
+    def has_matching_principals(self, pattern=r"*"):
+        for principal in self.principals:
+            if isinstance(principal, str) and re.match(pattern, principal):
+                return True
+        return False
+
     def has_nonwhitelisted_principals(self, whitelist):
         for principal in self.principals:
             if principal not in whitelist:

--- a/pycfmodel/model/resources/properties/statement.py
+++ b/pycfmodel/model/resources/properties/statement.py
@@ -60,6 +60,17 @@ class Statement(object):
 
         return wildcard_principals
 
+    def matching_principals(self, pattern=r"*"):
+        if not self.principal:
+            return []
+
+        matching_principals = []
+        for principal in self.principal:
+            if principal.has_matching_principals(pattern):
+                matching_principals.append(principal)
+
+        return matching_principals
+
     def non_whitelisted_principals(self, whitelist):
         if not self.principal or self.condition:
             return []


### PR DESCRIPTION
The current `has_wildcard_principals` method will always return `True` for `*` principals. 
These new methods that allow to specify a pattern  and a set of effects, and will only return the statements whose principals match the pattern and with the desired effect.