### PR TITLE
The resolver now returns strings and fixes a bug with equal function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 0.6.0 - [2019-11-25]
+### Improvements
+- Improve equal function
+
+### Breaking Changes
+- Resolver now returns strings for most primitives
+
+
 ## 0.5.1 - [2019-11-25]
 ### Improvements
 - Add `NO_ECHO_WITH_VALUE` param value

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -12,6 +12,7 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+from datetime import date
 
 import pytest
 
@@ -181,7 +182,13 @@ def test_not(function, expected_output):
 
 
 @pytest.mark.parametrize(
-    "function, expected_output", [({"Fn::Equals": ["a", "a"]}, True), ({"Fn::Equals": ["a", "b"]}, False)]
+    "function, expected_output", [
+        ({"Fn::Equals": ["a", "a"]}, True),
+        ({"Fn::Equals": ["a", "b"]}, False),
+        ({"Fn::Equals": ["1123456789", 1123456789]}, True),
+        ({"Fn::Equals": ["2019-12-10", date(2019, 12, 10)]}, True),
+        ({"Fn::Equals": ["0.3", 0.3]}, True),
+    ]
 )
 def test_equals(function, expected_output):
     parameters = {}


### PR DESCRIPTION
This PR fixes an issue where conditions based on int accountIds would not match the AWS:AccountId parameter (as it's a string)