### PR TITLE
Add support for rules section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## 0.6.3 - [2020-XX-XX]
+## 0.6.3 - [2020-01-08]
 ### Added
+- Added support for `Rules` section in template
 - Added tests for `allowed_principals_with` and `non_whitelisted_allowed_principals`
 ### Fixes
 - Fix types in `allowed_principals_with`, `non_whitelisted_allowed_principals` and `PSEUDO_PARAMETERS`.

--- a/pycfmodel/model/cf_model.py
+++ b/pycfmodel/model/cf_model.py
@@ -34,6 +34,7 @@ class CFModel(CustomModel):
     Outputs: Optional[Dict[str, Dict[str, Union[str, Dict]]]] = {}
     Parameters: Optional[Dict[str, Parameter]] = {}
     Resources: Dict[str, Resolvable[Union[ResourceModels, GenericResource]]] = {}
+    Rules: Optional[Dict] = {}
     Transform: Optional[List]
 
     PSEUDO_PARAMETERS: ClassVar[Dict[str, Union[str, List[str]]]] = {

--- a/tests/test_cf_model.py
+++ b/tests/test_cf_model.py
@@ -30,6 +30,7 @@ def model():
             "Conditions": {},
             "Transform": [],
             "Resources": {"Logical ID": {"Type": "Resource type", "Properties": {"foo": "bar"}}},
+            "Rules": {},
             "Outputs": {},
         }
     )


### PR DESCRIPTION
AWS doesn't say anything about this section inside the docs (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html)
But it was made public here (https://aws.amazon.com/blogs/mt/how-to-perform-cross-parameter-validation-using-aws-cloudformation-rules-and-assertions/) and can be used