### PR TITLE
Update license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ If you are adding a new file it should have a header like this:
 
 ```
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/__init__.py
+++ b/pycfmodel/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/constants.py
+++ b/pycfmodel/constants.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/base.py
+++ b/pycfmodel/model/base.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/cf_model.py
+++ b/pycfmodel/model/cf_model.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/parameter.py
+++ b/pycfmodel/model/parameter.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/generic_resource.py
+++ b/pycfmodel/model/resources/generic_resource.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/iam_group.py
+++ b/pycfmodel/model/resources/iam_group.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/iam_managed_policy.py
+++ b/pycfmodel/model/resources/iam_managed_policy.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/iam_policy.py
+++ b/pycfmodel/model/resources/iam_policy.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/iam_role.py
+++ b/pycfmodel/model/resources/iam_role.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/iam_user.py
+++ b/pycfmodel/model/resources/iam_user.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/kms_key.py
+++ b/pycfmodel/model/resources/kms_key.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/properties/policy.py
+++ b/pycfmodel/model/resources/properties/policy.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/properties/policy_document.py
+++ b/pycfmodel/model/resources/properties/policy_document.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/properties/property.py
+++ b/pycfmodel/model/resources/properties/property.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/properties/security_group_egress_prop.py
+++ b/pycfmodel/model/resources/properties/security_group_egress_prop.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/properties/security_group_ingress_prop.py
+++ b/pycfmodel/model/resources/properties/security_group_ingress_prop.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/properties/statement.py
+++ b/pycfmodel/model/resources/properties/statement.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/resource.py
+++ b/pycfmodel/model/resources/resource.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/s3_bucket_policy.py
+++ b/pycfmodel/model/resources/s3_bucket_policy.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/security_group.py
+++ b/pycfmodel/model/resources/security_group.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/security_group_egress.py
+++ b/pycfmodel/model/resources/security_group_egress.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/security_group_ingress.py
+++ b/pycfmodel/model/resources/security_group_ingress.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/sns_topic_policy.py
+++ b/pycfmodel/model/resources/sns_topic_policy.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/sqs_queue_policy.py
+++ b/pycfmodel/model/resources/sqs_queue_policy.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/resources/types.py
+++ b/pycfmodel/model/resources/types.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/model/types.py
+++ b/pycfmodel/model/types.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/resolver.py
+++ b/pycfmodel/resolver.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/pycfmodel/utils.py
+++ b/pycfmodel/utils.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/resources/properties/test_policy_document.py
+++ b/tests/resources/properties/test_policy_document.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/resources/properties/test_statement.py
+++ b/tests/resources/properties/test_statement.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/resources/test_iam_role.py
+++ b/tests/resources/test_iam_role.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/resources/test_iam_user.py
+++ b/tests/resources/test_iam_user.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/resources/test_s3_bucket_policy.py
+++ b/tests/resources/test_s3_bucket_policy.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/resources/test_security_group.py
+++ b/tests/resources/test_security_group.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/resources/test_security_group_egress.py
+++ b/tests/resources/test_security_group_egress.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/resources/test_security_group_ingress.py
+++ b/tests/resources/test_security_group_ingress.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/resources/test_sns_topic_policy.py
+++ b/tests/resources/test_sns_topic_policy.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/resources/test_sqs_queue_policy.py
+++ b/tests/resources/test_sqs_queue_policy.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/test_cf_model.py
+++ b/tests/test_cf_model.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/test_regexs.py
+++ b/tests/test_regexs.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.


### PR DESCRIPTION
Changes from `Copyright 2018-2019 Skyscanner Ltd` to `Copyright 2018-2020 Skyscanner Ltd`