### PR TITLE
Allow multiple operands in `or` and `and` functions. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 0.6.4 - [2020-02-27]
+### Fixes
+- Allow multiple operands in `or` and `and` functions. 
+
+
 ## 0.6.3 - [2020-01-08]
 ### Added
 - Added support for `Rules` section in template

--- a/pycfmodel/resolver.py
+++ b/pycfmodel/resolver.py
@@ -142,17 +142,11 @@ def resolve_if(function_body, params: Dict, mappings: Dict[str, Dict], condition
 
 
 def resolve_and(function_body: List, params: Dict, mappings: Dict[str, Dict], conditions: Dict[str, bool]) -> bool:
-    part_1, part_2 = function_body
-    resolve_1 = resolve(part_1, params, mappings, conditions)
-    resolve_2 = resolve(part_2, params, mappings, conditions)
-    return _extended_bool(resolve_1) and _extended_bool(resolve_2)
+    return all(_extended_bool(resolve(part, params, mappings, conditions)) for part in function_body)
 
 
 def resolve_or(function_body: List, params: Dict, mappings: Dict[str, Dict], conditions: Dict[str, bool]) -> bool:
-    part_1, part_2 = function_body
-    resolve_1 = resolve(part_1, params, mappings, conditions)
-    resolve_2 = resolve(part_2, params, mappings, conditions)
-    return _extended_bool(resolve_1) or _extended_bool(resolve_2)
+    return any(_extended_bool(resolve(part, params, mappings, conditions)) for part in function_body)
 
 
 def resolve_not(function_body: List, params: Dict, mappings: Dict[str, Dict], conditions: Dict[str, bool]) -> bool:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ dev_requires = ["black==19.3b0", "pytest==3.6.0", "flake8>=3.3.0", "pytest-cov>=
 
 setup(
     name="pycfmodel",
-    version="0.6.3",
+    version="0.6.4",
     description="A python model for CloudFormation scripts",
     author="Skyscanner Product Security",
     author_email="security@skyscanner.net",

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -146,6 +146,12 @@ def test_if(function, expected_output):
         ({"Fn::And": [False, True]}, False),
         ({"Fn::And": [True, False]}, False),
         ({"Fn::And": [False, False]}, False),
+        ({"Fn::And": [True, True, True]}, True),
+        ({"Fn::And": [False, True, False]}, False),
+        ({"Fn::And": [False, False, False]}, False),
+        ({"Fn::And": [True, True, True, True]}, True),
+        ({"Fn::And": [False, True, False, True]}, False),
+        ({"Fn::And": [False, False, False, False]}, False),
     ],
 )
 def test_and(function, expected_output):
@@ -163,6 +169,12 @@ def test_and(function, expected_output):
         ({"Fn::Or": [False, True]}, True),
         ({"Fn::Or": [True, False]}, True),
         ({"Fn::Or": [False, False]}, False),
+        ({"Fn::Or": [True, True, True]}, True),
+        ({"Fn::Or": [False, True, False]}, True),
+        ({"Fn::Or": [False, False, False]}, False),
+        ({"Fn::Or": [True, True, True, True]}, True),
+        ({"Fn::Or": [False, True, False, True]}, True),
+        ({"Fn::Or": [False, False, False, False]}, False),
     ],
 )
 def test_or(function, expected_output):


### PR DESCRIPTION
### Fixes
- Allow multiple operands in `or` and `and` functions. 
