### PR TITLE
Convert IP networks on Security Group resources to use IP Typing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ install-dev: install
 	pip install -e ".[dev]"
 
 format:
-	black .
+	black --exclude venv/ .
 
 lint:
-	black --check .
+	black --check --exclude venv/ .
 	flake8 pycfmodel/ # tests/
 
 component:

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ install-dev: install
 	pip install -e ".[dev]"
 
 format:
-	black --exclude venv/ .
+	black .
 
 lint:
-	black --check --exclude venv/ .
+	black --check .
 	flake8 pycfmodel/ # tests/
 
 component:

--- a/pycfmodel/constants.py
+++ b/pycfmodel/constants.py
@@ -69,3 +69,6 @@ CONDITION_FUNCTIONS = {
 
 CONTAINS_STAR = re.compile(r"^.*[*].*$")
 CONTAINS_CF_PARAM = re.compile(r"(\$\{[\w\:]+\})")
+
+IPV4_MASK_VALUE = "255.255.255.255"
+IPV6_MASK_VALUE = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"

--- a/pycfmodel/constants.py
+++ b/pycfmodel/constants.py
@@ -70,5 +70,5 @@ CONDITION_FUNCTIONS = {
 CONTAINS_STAR = re.compile(r"^.*[*].*$")
 CONTAINS_CF_PARAM = re.compile(r"(\$\{[\w\:]+\})")
 
-IPV4_MASK_VALUE = "255.255.255.255"
-IPV6_MASK_VALUE = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"
+IPV4_ZERO_VALUE = "0.0.0.0/0"
+IPV6_ZERO_VALUE = "::/0"

--- a/pycfmodel/model/resources/properties/security_group_egress_prop.py
+++ b/pycfmodel/model/resources/properties/security_group_egress_prop.py
@@ -12,11 +12,11 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from ipaddress import IPv4Address, IPv6Address, IPv4Network, IPv6Network
+from ipaddress import IPv4Network, IPv6Network
 from typing import Optional
 from pydantic import validator
 
-from ....constants import IPV4_MASK_VALUE, IPV6_MASK_VALUE
+from ....constants import IPV4_ZERO_VALUE, IPV6_ZERO_VALUE
 from ...types import ResolvableStr, ResolvableInt, ResolvableIntOrStr, ResolvableIPv4Network, ResolvableIPv6Network
 from .property import Property
 
@@ -42,9 +42,9 @@ class SecurityGroupEgressProp(Property):
     def ipv4_slash_zero(self) -> bool:
         if not self.CidrIp:
             return False
-        return self.CidrIp.hostmask == IPv4Address(IPV4_MASK_VALUE)
+        return self.CidrIp == IPv4Network(IPV4_ZERO_VALUE)
 
     def ipv6_slash_zero(self) -> bool:
         if not self.CidrIpv6:
             return False
-        return self.CidrIpv6.hostmask == IPv6Address(IPV6_MASK_VALUE)
+        return self.CidrIpv6 == IPv6Network(IPV6_ZERO_VALUE)

--- a/pycfmodel/model/resources/properties/security_group_egress_prop.py
+++ b/pycfmodel/model/resources/properties/security_group_egress_prop.py
@@ -14,16 +14,13 @@ specific language governing permissions and limitations under the License.
 """
 from typing import Optional
 
-from ...types import ResolvableStr, ResolvableInt, ResolvableIntOrStr
+from ...types import ResolvableStr, ResolvableInt, ResolvableIntOrStr, ResolvableIPv4Network, ResolvableIPv6Network
 from .property import Property
 
 
-import ipaddress
-
-
 class SecurityGroupEgressProp(Property):
-    CidrIp: Optional[ResolvableStr] = None
-    CidrIpv6: Optional[ResolvableStr] = None
+    CidrIp: Optional[ResolvableIPv4Network] = None
+    CidrIpv6: Optional[ResolvableIPv6Network] = None
     Description: Optional[ResolvableStr] = None
     DestinationPrefixListId: Optional[ResolvableStr] = None
     DestinationSecurityGroupId: Optional[ResolvableStr] = None
@@ -32,35 +29,11 @@ class SecurityGroupEgressProp(Property):
     ToPort: Optional[ResolvableInt] = None
 
     def ipv4_slash_zero(self) -> bool:
-        if not self.CidrIp or not isinstance(self.CidrIp, str):
+        if not self.CidrIp:
             return False
-        return self.CidrIp.endswith("/0")
+        return str(self.CidrIp).endswith("/0")
 
     def ipv6_slash_zero(self) -> bool:
-        if not self.CidrIpv6 or not isinstance(self.CidrIpv6, str):
+        if not self.CidrIpv6:
             return False
-        return self.CidrIpv6.endswith("/0")
-
-    def ipv4_private_addr(self) -> bool:
-        if not self.CidrIp or not isinstance(self.CidrIp, str):
-            return False
-
-        try:
-            return ipaddress.IPv4Network(self.CidrIp).is_private
-        except ValueError:
-            try:
-                return ipaddress.IPv4Address(self.CidrIp).is_private
-            except ValueError:
-                return False
-
-    def ipv6_private_addr(self) -> bool:
-        if not self.CidrIpv6 or not isinstance(self.CidrIpv6, str):
-            return False
-
-        try:
-            return ipaddress.IPv6Network(self.CidrIpv6).is_private
-        except ValueError:
-            try:
-                return ipaddress.IPv6Address(self.CidrIpv6).is_private
-            except ValueError:
-                return False
+        return str(self.CidrIpv6).endswith("/0")

--- a/pycfmodel/model/resources/properties/security_group_egress_prop.py
+++ b/pycfmodel/model/resources/properties/security_group_egress_prop.py
@@ -18,6 +18,9 @@ from ...types import ResolvableStr, ResolvableInt, ResolvableIntOrStr
 from .property import Property
 
 
+import ipaddress
+
+
 class SecurityGroupEgressProp(Property):
     CidrIp: Optional[ResolvableStr] = None
     CidrIpv6: Optional[ResolvableStr] = None
@@ -39,14 +42,25 @@ class SecurityGroupEgressProp(Property):
         return self.CidrIpv6.endswith("/0")
 
     def ipv4_private_addr(self) -> bool:
-        # follows https://tools.ietf.org/html/rfc1918
         if not self.CidrIp or not isinstance(self.CidrIp, str):
             return False
-        private_blocks = set({"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"})
-        return self.CidrIp in private_blocks
+
+        try:
+            return ipaddress.IPv4Network(self.CidrIp).is_private
+        except ValueError:
+            try:
+                return ipaddress.IPv4Address(self.CidrIp).is_private
+            except ValueError:
+                return False
 
     def ipv6_private_addr(self) -> bool:
-        # follows https://tools.ietf.org/html/rfc4193
         if not self.CidrIpv6 or not isinstance(self.CidrIpv6, str):
             return False
-        return self.CidrIpv6.lower().startswith("fc") or self.CidrIpv6.lower().startswith("fd")
+
+        try:
+            return ipaddress.IPv6Network(self.CidrIpv6).is_private
+        except ValueError:
+            try:
+                return ipaddress.IPv6Address(self.CidrIpv6).is_private
+            except ValueError:
+                return False

--- a/pycfmodel/model/resources/properties/security_group_egress_prop.py
+++ b/pycfmodel/model/resources/properties/security_group_egress_prop.py
@@ -37,3 +37,16 @@ class SecurityGroupEgressProp(Property):
         if not self.CidrIpv6 or not isinstance(self.CidrIpv6, str):
             return False
         return self.CidrIpv6.endswith("/0")
+
+    def ipv4_private_addr(self) -> bool:
+        # follows https://tools.ietf.org/html/rfc1918
+        if not self.CidrIp or not isinstance(self.CidrIp, str):
+            return False
+        private_blocks = set({"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"})
+        return self.CidrIp in private_blocks
+
+    def ipv6_private_addr(self) -> bool:
+        # follows https://tools.ietf.org/html/rfc4193
+        if not self.CidrIpv6 or not isinstance(self.CidrIpv6, str):
+            return False
+        return self.CidrIpv6.lower().startswith("fc") or self.CidrIpv6.lower().startswith("fd")

--- a/pycfmodel/model/resources/properties/security_group_egress_prop.py
+++ b/pycfmodel/model/resources/properties/security_group_egress_prop.py
@@ -12,8 +12,9 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from ipaddress import IPv4Address, IPv6Address
+from ipaddress import IPv4Address, IPv6Address, IPv4Network, IPv6Network
 from typing import Optional
+from pydantic import validator
 
 from ....constants import IPV4_MASK_VALUE, IPV6_MASK_VALUE
 from ...types import ResolvableStr, ResolvableInt, ResolvableIntOrStr, ResolvableIPv4Network, ResolvableIPv6Network
@@ -29,6 +30,14 @@ class SecurityGroupEgressProp(Property):
     FromPort: Optional[ResolvableInt] = None
     IpProtocol: ResolvableIntOrStr
     ToPort: Optional[ResolvableInt] = None
+
+    @validator("CidrIp", pre=True)
+    def set_CidrIp(cls, v):
+        return IPv4Network(v, strict=False)
+
+    @validator("CidrIpv6", pre=True)
+    def set_CidrIpv6(cls, v):
+        return IPv6Network(v, strict=False)
 
     def ipv4_slash_zero(self) -> bool:
         if not self.CidrIp:

--- a/pycfmodel/model/resources/properties/security_group_egress_prop.py
+++ b/pycfmodel/model/resources/properties/security_group_egress_prop.py
@@ -12,8 +12,10 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+from ipaddress import IPv4Address, IPv6Address
 from typing import Optional
 
+from ....constants import IPV4_MASK_VALUE, IPV6_MASK_VALUE
 from ...types import ResolvableStr, ResolvableInt, ResolvableIntOrStr, ResolvableIPv4Network, ResolvableIPv6Network
 from .property import Property
 
@@ -31,9 +33,9 @@ class SecurityGroupEgressProp(Property):
     def ipv4_slash_zero(self) -> bool:
         if not self.CidrIp:
             return False
-        return str(self.CidrIp).endswith("/0")
+        return self.CidrIp.hostmask == IPv4Address(IPV4_MASK_VALUE)
 
     def ipv6_slash_zero(self) -> bool:
         if not self.CidrIpv6:
             return False
-        return str(self.CidrIpv6).endswith("/0")
+        return self.CidrIpv6.hostmask == IPv6Address(IPV6_MASK_VALUE)

--- a/pycfmodel/model/resources/properties/security_group_ingress_prop.py
+++ b/pycfmodel/model/resources/properties/security_group_ingress_prop.py
@@ -39,3 +39,16 @@ class SecurityGroupIngressProp(Property):
         if not self.CidrIpv6 or not isinstance(self.CidrIpv6, str):
             return False
         return self.CidrIpv6.endswith("/0")
+
+    def ipv4_private_addr(self) -> bool:
+        # follows https://tools.ietf.org/html/rfc1918
+        if not self.CidrIp or not isinstance(self.CidrIp, str):
+            return False
+        private_blocks = set({"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"})
+        return self.CidrIp in private_blocks
+
+    def ipv6_private_addr(self) -> bool:
+        # follows https://tools.ietf.org/html/rfc4193
+        if not self.CidrIpv6 or not isinstance(self.CidrIpv6, str):
+            return False
+        return self.CidrIpv6.lower().startswith("fc") or self.CidrIpv6.lower().startswith("fd")

--- a/pycfmodel/model/resources/properties/security_group_ingress_prop.py
+++ b/pycfmodel/model/resources/properties/security_group_ingress_prop.py
@@ -12,8 +12,9 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from ipaddress import IPv4Address, IPv6Address
+from ipaddress import IPv4Address, IPv6Address, IPv4Network, IPv6Network
 from typing import Optional
+from pydantic import validator
 
 from ....constants import IPV4_MASK_VALUE, IPV6_MASK_VALUE
 from ...types import ResolvableStr, ResolvableInt, ResolvableIntOrStr, ResolvableIPv4Network, ResolvableIPv6Network
@@ -31,6 +32,14 @@ class SecurityGroupIngressProp(Property):
     SourceSecurityGroupName: Optional[ResolvableStr] = None
     SourceSecurityGroupOwnerId: Optional[ResolvableStr] = None
     ToPort: Optional[ResolvableInt] = None
+
+    @validator("CidrIp", pre=True)
+    def set_CidrIp(cls, v):
+        return IPv4Network(v, strict=False)
+
+    @validator("CidrIpv6", pre=True)
+    def set_CidrIpv6(cls, v):
+        return IPv6Network(v, strict=False)
 
     def ipv4_slash_zero(self) -> bool:
         if not self.CidrIp:

--- a/pycfmodel/model/resources/properties/security_group_ingress_prop.py
+++ b/pycfmodel/model/resources/properties/security_group_ingress_prop.py
@@ -12,11 +12,11 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from ipaddress import IPv4Address, IPv6Address, IPv4Network, IPv6Network
+from ipaddress import IPv4Network, IPv6Network
 from typing import Optional
 from pydantic import validator
 
-from ....constants import IPV4_MASK_VALUE, IPV6_MASK_VALUE
+from ....constants import IPV4_ZERO_VALUE, IPV6_ZERO_VALUE
 from ...types import ResolvableStr, ResolvableInt, ResolvableIntOrStr, ResolvableIPv4Network, ResolvableIPv6Network
 from .property import Property
 
@@ -44,9 +44,9 @@ class SecurityGroupIngressProp(Property):
     def ipv4_slash_zero(self) -> bool:
         if not self.CidrIp:
             return False
-        return self.CidrIp.hostmask == IPv4Address(IPV4_MASK_VALUE)
+        return self.CidrIp == IPv4Network(IPV4_ZERO_VALUE)
 
     def ipv6_slash_zero(self) -> bool:
         if not self.CidrIpv6:
             return False
-        return self.CidrIpv6.hostmask == IPv6Address(IPV6_MASK_VALUE)
+        return self.CidrIpv6 == IPv6Network(IPV6_ZERO_VALUE)

--- a/pycfmodel/model/resources/properties/security_group_ingress_prop.py
+++ b/pycfmodel/model/resources/properties/security_group_ingress_prop.py
@@ -12,8 +12,10 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+from ipaddress import IPv4Address, IPv6Address
 from typing import Optional
 
+from ....constants import IPV4_MASK_VALUE, IPV6_MASK_VALUE
 from ...types import ResolvableStr, ResolvableInt, ResolvableIntOrStr, ResolvableIPv4Network, ResolvableIPv6Network
 from .property import Property
 
@@ -33,9 +35,9 @@ class SecurityGroupIngressProp(Property):
     def ipv4_slash_zero(self) -> bool:
         if not self.CidrIp:
             return False
-        return str(self.CidrIp).endswith("/0")
+        return self.CidrIp.hostmask == IPv4Address(IPV4_MASK_VALUE)
 
     def ipv6_slash_zero(self) -> bool:
         if not self.CidrIpv6:
             return False
-        return str(self.CidrIpv6).endswith("/0")
+        return self.CidrIpv6.hostmask == IPv6Address(IPV6_MASK_VALUE)

--- a/pycfmodel/model/resources/properties/security_group_ingress_prop.py
+++ b/pycfmodel/model/resources/properties/security_group_ingress_prop.py
@@ -18,6 +18,9 @@ from ...types import ResolvableStr, ResolvableInt, ResolvableIntOrStr
 from .property import Property
 
 
+import ipaddress
+
+
 class SecurityGroupIngressProp(Property):
     CidrIp: Optional[ResolvableStr] = None
     CidrIpv6: Optional[ResolvableStr] = None
@@ -41,14 +44,25 @@ class SecurityGroupIngressProp(Property):
         return self.CidrIpv6.endswith("/0")
 
     def ipv4_private_addr(self) -> bool:
-        # follows https://tools.ietf.org/html/rfc1918
         if not self.CidrIp or not isinstance(self.CidrIp, str):
             return False
-        private_blocks = set({"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"})
-        return self.CidrIp in private_blocks
+
+        try:
+            return ipaddress.IPv4Network(self.CidrIp).is_private
+        except ValueError:
+            try:
+                return ipaddress.IPv4Address(self.CidrIp).is_private
+            except ValueError:
+                return False
 
     def ipv6_private_addr(self) -> bool:
-        # follows https://tools.ietf.org/html/rfc4193
         if not self.CidrIpv6 or not isinstance(self.CidrIpv6, str):
             return False
-        return self.CidrIpv6.lower().startswith("fc") or self.CidrIpv6.lower().startswith("fd")
+
+        try:
+            return ipaddress.IPv6Network(self.Properties.CidrIpv6).is_private
+        except ValueError:
+            try:
+                return ipaddress.IPv6Address(self.Properties.CidrIpv6).is_private
+            except ValueError:
+                return False

--- a/pycfmodel/model/resources/properties/security_group_ingress_prop.py
+++ b/pycfmodel/model/resources/properties/security_group_ingress_prop.py
@@ -14,16 +14,13 @@ specific language governing permissions and limitations under the License.
 """
 from typing import Optional
 
-from ...types import ResolvableStr, ResolvableInt, ResolvableIntOrStr
+from ...types import ResolvableStr, ResolvableInt, ResolvableIntOrStr, ResolvableIPv4Network, ResolvableIPv6Network
 from .property import Property
 
 
-import ipaddress
-
-
 class SecurityGroupIngressProp(Property):
-    CidrIp: Optional[ResolvableStr] = None
-    CidrIpv6: Optional[ResolvableStr] = None
+    CidrIp: Optional[ResolvableIPv4Network] = None
+    CidrIpv6: Optional[ResolvableIPv6Network] = None
     Description: Optional[ResolvableStr] = None
     FromPort: Optional[ResolvableInt] = None
     IpProtocol: ResolvableIntOrStr
@@ -34,35 +31,11 @@ class SecurityGroupIngressProp(Property):
     ToPort: Optional[ResolvableInt] = None
 
     def ipv4_slash_zero(self) -> bool:
-        if not self.CidrIp or not isinstance(self.CidrIp, str):
+        if not self.CidrIp:
             return False
-        return self.CidrIp.endswith("/0")
+        return str(self.CidrIp).endswith("/0")
 
     def ipv6_slash_zero(self) -> bool:
-        if not self.CidrIpv6 or not isinstance(self.CidrIpv6, str):
+        if not self.CidrIpv6:
             return False
-        return self.CidrIpv6.endswith("/0")
-
-    def ipv4_private_addr(self) -> bool:
-        if not self.CidrIp or not isinstance(self.CidrIp, str):
-            return False
-
-        try:
-            return ipaddress.IPv4Network(self.CidrIp).is_private
-        except ValueError:
-            try:
-                return ipaddress.IPv4Address(self.CidrIp).is_private
-            except ValueError:
-                return False
-
-    def ipv6_private_addr(self) -> bool:
-        if not self.CidrIpv6 or not isinstance(self.CidrIpv6, str):
-            return False
-
-        try:
-            return ipaddress.IPv6Network(self.Properties.CidrIpv6).is_private
-        except ValueError:
-            try:
-                return ipaddress.IPv6Address(self.Properties.CidrIpv6).is_private
-            except ValueError:
-                return False
+        return str(self.CidrIpv6).endswith("/0")

--- a/pycfmodel/model/resources/security_group_egress.py
+++ b/pycfmodel/model/resources/security_group_egress.py
@@ -12,8 +12,10 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+from ipaddress import IPv4Address, IPv6Address
 from typing import ClassVar, Optional
 
+from ...constants import IPV4_MASK_VALUE, IPV6_MASK_VALUE
 from ..types import ResolvableStr, ResolvableInt, ResolvableIntOrStr, ResolvableIPv4Network, ResolvableIPv6Network
 from ..base import CustomModel
 from .resource import Resource
@@ -39,9 +41,9 @@ class SecurityGroupEgress(Resource):
     def ipv4_slash_zero(self) -> bool:
         if not self.Properties.CidrIp:
             return False
-        return str(self.Properties.CidrIp).endswith("/0")
+        return self.Properties.CidrIp.hostmask == IPv4Address(IPV4_MASK_VALUE)
 
     def ipv6_slash_zero(self) -> bool:
         if not self.Properties.CidrIpv6:
             return False
-        return str(self.Properties.CidrIpv6).endswith("/0")
+        return self.Properties.CidrIpv6.hostmask == IPv6Address(IPV6_MASK_VALUE)

--- a/pycfmodel/model/resources/security_group_egress.py
+++ b/pycfmodel/model/resources/security_group_egress.py
@@ -12,8 +12,9 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from ipaddress import IPv4Address, IPv6Address
+from ipaddress import IPv4Address, IPv6Address, IPv4Network, IPv6Network
 from typing import ClassVar, Optional
+from pydantic import validator
 
 from ...constants import IPV4_MASK_VALUE, IPV6_MASK_VALUE
 from ..types import ResolvableStr, ResolvableInt, ResolvableIntOrStr, ResolvableIPv4Network, ResolvableIPv6Network
@@ -31,6 +32,14 @@ class SecurityGroupEgressProperties(CustomModel):
     GroupId: Optional[ResolvableStr] = None
     IpProtocol: ResolvableIntOrStr
     ToPort: Optional[ResolvableInt] = None
+
+    @validator("CidrIp", pre=True)
+    def set_CidrIp(cls, v):
+        return IPv4Network(v, strict=False)
+
+    @validator("CidrIpv6", pre=True)
+    def set_CidrIpv6(cls, v):
+        return IPv6Network(v, strict=False)
 
 
 class SecurityGroupEgress(Resource):

--- a/pycfmodel/model/resources/security_group_egress.py
+++ b/pycfmodel/model/resources/security_group_egress.py
@@ -14,16 +14,14 @@ specific language governing permissions and limitations under the License.
 """
 from typing import ClassVar, Optional
 
-from ..types import ResolvableStr, ResolvableInt, ResolvableIntOrStr
+from ..types import ResolvableStr, ResolvableInt, ResolvableIntOrStr, ResolvableIPv4Network, ResolvableIPv6Network
 from ..base import CustomModel
 from .resource import Resource
 
-import ipaddress
-
 
 class SecurityGroupEgressProperties(CustomModel):
-    CidrIp: Optional[ResolvableStr] = None
-    CidrIpv6: Optional[ResolvableStr] = None
+    CidrIp: Optional[ResolvableIPv4Network] = None
+    CidrIpv6: Optional[ResolvableIPv6Network] = None
     Description: Optional[ResolvableStr] = None
     DestinationPrefixListId: Optional[ResolvableStr] = None
     DestinationSecurityGroupId: Optional[ResolvableStr] = None
@@ -39,35 +37,11 @@ class SecurityGroupEgress(Resource):
     Properties: SecurityGroupEgressProperties
 
     def ipv4_slash_zero(self) -> bool:
-        if not self.Properties.CidrIp or not isinstance(self.Properties.CidrIp, str):
+        if not self.Properties.CidrIp:
             return False
-        return self.Properties.CidrIp.endswith("/0")
+        return str(self.Properties.CidrIp).endswith("/0")
 
     def ipv6_slash_zero(self) -> bool:
-        if not self.Properties.CidrIpv6 or not isinstance(self.Properties.CidrIpv6, str):
+        if not self.Properties.CidrIpv6:
             return False
-        return self.Properties.CidrIpv6.endswith("/0")
-
-    def ipv4_private_addr(self) -> bool:
-        if not self.Properties.CidrIp or not isinstance(self.Properties.CidrIp, str):
-            return False
-
-        try:
-            return ipaddress.IPv4Network(self.Properties.CidrIp).is_private
-        except ValueError:
-            try:
-                return ipaddress.IPv4Address(self.Properties.CidrIp).is_private
-            except ValueError:
-                return False
-
-    def ipv6_private_addr(self) -> bool:
-        if not self.Properties.CidrIpv6 or not isinstance(self.Properties.CidrIpv6, str):
-            return False
-
-        try:
-            return ipaddress.IPv6Network(self.Properties.CidrIpv6).is_private
-        except ValueError:
-            try:
-                return ipaddress.IPv6Address(self.Properties.CidrIpv6).is_private
-            except ValueError:
-                return False
+        return str(self.Properties.CidrIpv6).endswith("/0")

--- a/pycfmodel/model/resources/security_group_egress.py
+++ b/pycfmodel/model/resources/security_group_egress.py
@@ -18,6 +18,8 @@ from ..types import ResolvableStr, ResolvableInt, ResolvableIntOrStr
 from ..base import CustomModel
 from .resource import Resource
 
+import ipaddress
+
 
 class SecurityGroupEgressProperties(CustomModel):
     CidrIp: Optional[ResolvableStr] = None
@@ -47,14 +49,25 @@ class SecurityGroupEgress(Resource):
         return self.Properties.CidrIpv6.endswith("/0")
 
     def ipv4_private_addr(self) -> bool:
-        # follows https://tools.ietf.org/html/rfc1918
         if not self.Properties.CidrIp or not isinstance(self.Properties.CidrIp, str):
             return False
-        private_blocks = set({"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"})
-        return self.Properties.CidrIp in private_blocks
+
+        try:
+            return ipaddress.IPv4Network(self.Properties.CidrIp).is_private
+        except ValueError:
+            try:
+                return ipaddress.IPv4Address(self.Properties.CidrIp).is_private
+            except ValueError:
+                return False
 
     def ipv6_private_addr(self) -> bool:
-        # follows https://tools.ietf.org/html/rfc4193
         if not self.Properties.CidrIpv6 or not isinstance(self.Properties.CidrIpv6, str):
             return False
-        return self.Properties.CidrIpv6.lower().startswith("fc") or self.Properties.CidrIpv6.lower().startswith("fd")
+
+        try:
+            return ipaddress.IPv6Network(self.Properties.CidrIpv6).is_private
+        except ValueError:
+            try:
+                return ipaddress.IPv6Address(self.Properties.CidrIpv6).is_private
+            except ValueError:
+                return False

--- a/pycfmodel/model/resources/security_group_egress.py
+++ b/pycfmodel/model/resources/security_group_egress.py
@@ -12,11 +12,11 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from ipaddress import IPv4Address, IPv6Address, IPv4Network, IPv6Network
+from ipaddress import IPv4Network, IPv6Network
 from typing import ClassVar, Optional
 from pydantic import validator
 
-from ...constants import IPV4_MASK_VALUE, IPV6_MASK_VALUE
+from ...constants import IPV4_ZERO_VALUE, IPV6_ZERO_VALUE
 from ..types import ResolvableStr, ResolvableInt, ResolvableIntOrStr, ResolvableIPv4Network, ResolvableIPv6Network
 from ..base import CustomModel
 from .resource import Resource
@@ -50,9 +50,9 @@ class SecurityGroupEgress(Resource):
     def ipv4_slash_zero(self) -> bool:
         if not self.Properties.CidrIp:
             return False
-        return self.Properties.CidrIp.hostmask == IPv4Address(IPV4_MASK_VALUE)
+        return self.Properties.CidrIp == IPv4Network(IPV4_ZERO_VALUE)
 
     def ipv6_slash_zero(self) -> bool:
         if not self.Properties.CidrIpv6:
             return False
-        return self.Properties.CidrIpv6.hostmask == IPv6Address(IPV6_MASK_VALUE)
+        return self.Properties.CidrIpv6 == IPv6Network(IPV6_ZERO_VALUE)

--- a/pycfmodel/model/resources/security_group_egress.py
+++ b/pycfmodel/model/resources/security_group_egress.py
@@ -45,3 +45,16 @@ class SecurityGroupEgress(Resource):
         if not self.Properties.CidrIpv6 or not isinstance(self.Properties.CidrIpv6, str):
             return False
         return self.Properties.CidrIpv6.endswith("/0")
+
+    def ipv4_private_addr(self) -> bool:
+        # follows https://tools.ietf.org/html/rfc1918
+        if not self.Properties.CidrIp or not isinstance(self.Properties.CidrIp, str):
+            return False
+        private_blocks = set({"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"})
+        return self.Properties.CidrIp in private_blocks
+
+    def ipv6_private_addr(self) -> bool:
+        # follows https://tools.ietf.org/html/rfc4193
+        if not self.Properties.CidrIpv6 or not isinstance(self.Properties.CidrIpv6, str):
+            return False
+        return self.Properties.CidrIpv6.lower().startswith("fc") or self.Properties.CidrIpv6.lower().startswith("fd")

--- a/pycfmodel/model/resources/security_group_ingress.py
+++ b/pycfmodel/model/resources/security_group_ingress.py
@@ -12,11 +12,11 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from ipaddress import IPv4Address, IPv6Address, IPv4Network, IPv6Network
+from ipaddress import IPv4Network, IPv6Network
 from typing import ClassVar, Optional
 from pydantic import validator
 
-from ...constants import IPV4_MASK_VALUE, IPV6_MASK_VALUE
+from ...constants import IPV4_ZERO_VALUE, IPV6_ZERO_VALUE
 from ..types import ResolvableStr, ResolvableIntOrStr, ResolvableInt, ResolvableIPv4Network, ResolvableIPv6Network
 from ..base import CustomModel
 from .resource import Resource
@@ -53,9 +53,9 @@ class SecurityGroupIngress(Resource):
     def ipv4_slash_zero(self) -> bool:
         if not self.Properties.CidrIp:
             return False
-        return self.Properties.CidrIp.hostmask == IPv4Address(IPV4_MASK_VALUE)
+        return self.Properties.CidrIp == IPv4Network(IPV4_ZERO_VALUE)
 
     def ipv6_slash_zero(self) -> bool:
         if not self.Properties.CidrIpv6:
             return False
-        return self.Properties.CidrIpv6.hostmask == IPv6Address(IPV6_MASK_VALUE)
+        return self.Properties.CidrIpv6 == IPv6Network(IPV6_ZERO_VALUE)

--- a/pycfmodel/model/resources/security_group_ingress.py
+++ b/pycfmodel/model/resources/security_group_ingress.py
@@ -12,8 +12,9 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from ipaddress import IPv4Address, IPv6Address
+from ipaddress import IPv4Address, IPv6Address, IPv4Network, IPv6Network
 from typing import ClassVar, Optional
+from pydantic import validator
 
 from ...constants import IPV4_MASK_VALUE, IPV6_MASK_VALUE
 from ..types import ResolvableStr, ResolvableIntOrStr, ResolvableInt, ResolvableIPv4Network, ResolvableIPv6Network
@@ -34,6 +35,14 @@ class SecurityGroupIngressProperties(CustomModel):
     SourceSecurityGroupName: Optional[ResolvableStr] = None
     SourceSecurityGroupOwnerId: Optional[ResolvableStr] = None
     ToPort: Optional[ResolvableInt] = None
+
+    @validator("CidrIp", pre=True)
+    def set_CidrIp(cls, v):
+        return IPv4Network(v, strict=False)
+
+    @validator("CidrIpv6", pre=True)
+    def set_CidrIpv6(cls, v):
+        return IPv6Network(v, strict=False)
 
 
 class SecurityGroupIngress(Resource):

--- a/pycfmodel/model/resources/security_group_ingress.py
+++ b/pycfmodel/model/resources/security_group_ingress.py
@@ -12,8 +12,10 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+from ipaddress import IPv4Address, IPv6Address
 from typing import ClassVar, Optional
 
+from ...constants import IPV4_MASK_VALUE, IPV6_MASK_VALUE
 from ..types import ResolvableStr, ResolvableIntOrStr, ResolvableInt, ResolvableIPv4Network, ResolvableIPv6Network
 from ..base import CustomModel
 from .resource import Resource
@@ -42,9 +44,9 @@ class SecurityGroupIngress(Resource):
     def ipv4_slash_zero(self) -> bool:
         if not self.Properties.CidrIp:
             return False
-        return str(self.Properties.CidrIp).endswith("/0")
+        return self.Properties.CidrIp.hostmask == IPv4Address(IPV4_MASK_VALUE)
 
     def ipv6_slash_zero(self) -> bool:
         if not self.Properties.CidrIpv6:
             return False
-        return str(self.Properties.CidrIpv6).endswith("/0")
+        return self.Properties.CidrIpv6.hostmask == IPv6Address(IPV6_MASK_VALUE)

--- a/pycfmodel/model/resources/security_group_ingress.py
+++ b/pycfmodel/model/resources/security_group_ingress.py
@@ -14,17 +14,14 @@ specific language governing permissions and limitations under the License.
 """
 from typing import ClassVar, Optional
 
-from ..types import ResolvableStr, ResolvableIntOrStr, ResolvableInt
+from ..types import ResolvableStr, ResolvableIntOrStr, ResolvableInt, ResolvableIPv4Network, ResolvableIPv6Network
 from ..base import CustomModel
 from .resource import Resource
 
 
-import ipaddress
-
-
 class SecurityGroupIngressProperties(CustomModel):
-    CidrIp: Optional[ResolvableStr] = None
-    CidrIpv6: Optional[ResolvableStr] = None
+    CidrIp: Optional[ResolvableIPv4Network] = None
+    CidrIpv6: Optional[ResolvableIPv6Network] = None
     Description: Optional[ResolvableStr] = None
     FromPort: Optional[ResolvableInt] = None
     GroupId: Optional[ResolvableStr] = None
@@ -43,35 +40,11 @@ class SecurityGroupIngress(Resource):
     Properties: SecurityGroupIngressProperties
 
     def ipv4_slash_zero(self) -> bool:
-        if not self.Properties.CidrIp or not isinstance(self.Properties.CidrIp, str):
+        if not self.Properties.CidrIp:
             return False
-        return self.Properties.CidrIp.endswith("/0")
+        return str(self.Properties.CidrIp).endswith("/0")
 
     def ipv6_slash_zero(self) -> bool:
-        if not self.Properties.CidrIpv6 or not isinstance(self.Properties.CidrIpv6, str):
+        if not self.Properties.CidrIpv6:
             return False
-        return self.Properties.CidrIpv6.endswith("/0")
-
-    def ipv4_private_addr(self) -> bool:
-        if not self.Properties.CidrIp or not isinstance(self.Properties.CidrIp, str):
-            return False
-
-        try:
-            return ipaddress.IPv4Network(self.Properties.CidrIp).is_private
-        except ValueError:
-            try:
-                return ipaddress.IPv4Address(self.Properties.CidrIp).is_private
-            except ValueError:
-                return False
-
-    def ipv6_private_addr(self) -> bool:
-        if not self.Properties.CidrIpv6 or not isinstance(self.Properties.CidrIpv6, str):
-            return False
-
-        try:
-            return ipaddress.IPv6Network(self.Properties.CidrIpv6).is_private
-        except ValueError:
-            try:
-                return ipaddress.IPv6Address(self.Properties.CidrIpv6).is_private
-            except ValueError:
-                return False
+        return str(self.Properties.CidrIpv6).endswith("/0")

--- a/pycfmodel/model/resources/security_group_ingress.py
+++ b/pycfmodel/model/resources/security_group_ingress.py
@@ -48,3 +48,16 @@ class SecurityGroupIngress(Resource):
         if not self.Properties.CidrIpv6 or not isinstance(self.Properties.CidrIpv6, str):
             return False
         return self.Properties.CidrIpv6.endswith("/0")
+
+    def ipv4_private_addr(self) -> bool:
+        # follows https://tools.ietf.org/html/rfc1918
+        if not self.Properties.CidrIp or not isinstance(self.Properties.CidrIp, str):
+            return False
+        private_blocks = set({"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"})
+        return self.Properties.CidrIp in private_blocks
+
+    def ipv6_private_addr(self) -> bool:
+        # follows https://tools.ietf.org/html/rfc4193
+        if not self.Properties.CidrIpv6 or not isinstance(self.Properties.CidrIpv6, str):
+            return False
+        return self.Properties.CidrIpv6.lower().startswith("fc") or self.Properties.CidrIpv6.lower().startswith("fd")

--- a/pycfmodel/model/types.py
+++ b/pycfmodel/model/types.py
@@ -13,6 +13,7 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
 from datetime import date
+from ipaddress import IPv4Network, IPv6Network
 from typing import Union, List, TypeVar
 
 from .base import FunctionDict, ConditionDict
@@ -26,5 +27,7 @@ ResolvableDate = Resolvable[date]
 ResolvableBool = Resolvable[bool]
 ResolvableStrOrList = Resolvable[Union[str, List]]
 ResolvableIntOrStr = Resolvable[Union[int, str]]
+ResolvableIPv4Network = Resolvable[IPv4Network]
+ResolvableIPv6Network = Resolvable[IPv6Network]
 
 ResolvableCondition = Union[ConditionDict, ResolvableStr]

--- a/pycfmodel/resolver.py
+++ b/pycfmodel/resolver.py
@@ -16,6 +16,7 @@ import logging
 
 from base64 import b64encode
 from datetime import date
+from ipaddress import IPv4Network, IPv6Network
 from typing import Dict, List, Union
 
 from pydantic import BaseModel
@@ -41,7 +42,7 @@ def resolve(function: ValidResolvers, params: Dict, mappings: Dict[str, Dict], c
     if function is None or isinstance(function, str):
         return function
 
-    if isinstance(function, (int, float, date, bool)):
+    if isinstance(function, (int, float, date, bool, IPv4Network, IPv6Network)):
         return str(function)
 
     if isinstance(function, list):
@@ -176,7 +177,7 @@ def resolve_get_azs(function_body, params: Dict, mappings: Dict[str, Dict], cond
 
 
 def resolve_condition(function_body, params: Dict, mappings: Dict[str, Dict], conditions: Dict[str, bool]) -> bool:
-    # TODO: Implement resolve conditions inside resourcesgit add .
+    # TODO: Implement resolve conditions inside resources
     return conditions.get(function_body, False)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
 [tool.black]
 line-length = 120
 target_version = ['py37']
+exclude = 'venv/'

--- a/tests/resources/test_security_group_egress.py
+++ b/tests/resources/test_security_group_egress.py
@@ -18,61 +18,53 @@ from pycfmodel.model.resources.security_group_egress import SecurityGroupEgress
 
 
 @pytest.fixture()
-def security_group_egress_ipv4():
+def security_group_egress_ipv4_1():
     return SecurityGroupEgress(
         **{
             "Type": "AWS::EC2::SecurityGroupEgress",
-            "Properties": {"GroupId": "sg-12341234", "CidrIp": "", "FromPort": 41, "ToPort": 45, "IpProtocol": "tcp"},
+            "Properties": {"GroupId": "sg-1", "CidrIp": "0.0.0.0/0", "FromPort": 41, "ToPort": 45, "IpProtocol": "tcp"},
         }
     )
 
 
 @pytest.fixture()
-def security_group_egress_ipv6():
+def security_group_egress_ipv4_2():
     return SecurityGroupEgress(
         **{
             "Type": "AWS::EC2::SecurityGroupEgress",
-            "Properties": {"GroupId": "sg-12341234", "CidrIpv6": "", "FromPort": 41, "ToPort": 45, "IpProtocol": "tcp"},
+            "Properties": {"GroupId": "sg-2", "CidrIp": "172.0.0.0", "FromPort": 41, "ToPort": 45, "IpProtocol": "tcp"},
         }
     )
 
 
-def test_security_group_egress(security_group_egress_ipv4):
-    assert security_group_egress_ipv4.Properties.GroupId == "sg-12341234"
-    assert isinstance(security_group_egress_ipv4.Properties.FromPort, int)
+@pytest.fixture()
+def security_group_egress_ipv6_1():
+    return SecurityGroupEgress(
+        **{
+            "Type": "AWS::EC2::SecurityGroupEgress",
+            "Properties": {
+                "GroupId": "sg-1",
+                "CidrIpv6": "fc00::/7",
+                "FromPort": 41,
+                "ToPort": 45,
+                "IpProtocol": "tcp",
+            },
+        }
+    )
 
 
-@pytest.mark.parametrize("ipv4, expected", [("1.1.1.1/0", True), (None, False), (1, False), ("172.16.0.0/12", False)])
-def test_slash_zero4(ipv4, expected, security_group_egress_ipv4):
-    security_group_egress_ipv4.Properties.CidrIp = ipv4
-    assert security_group_egress_ipv4.ipv4_slash_zero() == expected
+def test_security_group_egress(security_group_egress_ipv4_1):
+    assert security_group_egress_ipv4_1.Properties.GroupId == "sg-1"
+    assert isinstance(security_group_egress_ipv4_1.Properties.FromPort, int)
 
 
-@pytest.mark.parametrize("ipv6, expected", [("1.1.1.1/0", True), (None, False), (1, False), ("172.16.0.0/12", False)])
-def test_slash_zero6(ipv6, expected, security_group_egress_ipv6):
-    security_group_egress_ipv6.Properties.CidrIpv6 = ipv6
-    assert security_group_egress_ipv6.ipv6_slash_zero() == expected
+def test_slash_zero4(security_group_egress_ipv4_1):
+    assert security_group_egress_ipv4_1.ipv4_slash_zero() == True
 
 
-@pytest.mark.parametrize(
-    "ipv4, expected", [("1.1.1.1/0", False), ("10.0.0.0/8", True), (None, False), (1, False), ("172.0.0.0/8", False)]
-)
-def test_ipv4_private_addr(ipv4, expected, security_group_egress_ipv4):
-    security_group_egress_ipv4.Properties.CidrIp = ipv4
-    assert security_group_egress_ipv4.ipv4_private_addr() == expected
+def test_not_slash_zero4(security_group_egress_ipv4_2):
+    assert security_group_egress_ipv4_2.ipv4_slash_zero() == False
 
 
-@pytest.mark.parametrize(
-    "ipv6, expected",
-    [
-        ("1.1.1.1/0", False),
-        ("fc00::/7", True),
-        ("FD00::/8", True),
-        (None, False),
-        (1, False),
-        ("0001:0db8:85a3:0000:0000:8a2e:0370:7334", False),
-    ],
-)
-def test_ipv6_private_addr(ipv6, expected, security_group_egress_ipv6):
-    security_group_egress_ipv6.Properties.CidrIpv6 = ipv6
-    assert security_group_egress_ipv6.ipv6_private_addr() == expected
+def test_not_slash_zero6(security_group_egress_ipv6_1):
+    assert security_group_egress_ipv6_1.ipv6_slash_zero() == False

--- a/tests/resources/test_security_group_egress.py
+++ b/tests/resources/test_security_group_egress.py
@@ -22,7 +22,13 @@ def security_group_egress_ipv4_1():
     return SecurityGroupEgress(
         **{
             "Type": "AWS::EC2::SecurityGroupEgress",
-            "Properties": {"GroupId": "sg-1", "CidrIp": "0.0.0.0/0", "FromPort": 41, "ToPort": 45, "IpProtocol": "tcp"},
+            "Properties": {
+                "GroupId": "sg-12341234",
+                "CidrIp": "0.0.0.0/0",
+                "FromPort": 41,
+                "ToPort": 45,
+                "IpProtocol": "tcp",
+            },
         }
     )
 
@@ -32,18 +38,24 @@ def security_group_egress_ipv4_2():
     return SecurityGroupEgress(
         **{
             "Type": "AWS::EC2::SecurityGroupEgress",
-            "Properties": {"GroupId": "sg-2", "CidrIp": "172.0.0.0", "FromPort": 41, "ToPort": 45, "IpProtocol": "tcp"},
+            "Properties": {
+                "GroupId": "sg-2345",
+                "CidrIp": "172.0.0.0",
+                "FromPort": 41,
+                "ToPort": 45,
+                "IpProtocol": "tcp",
+            },
         }
     )
 
 
 @pytest.fixture()
-def security_group_egress_ipv6_1():
+def security_group_egress_ipv6():
     return SecurityGroupEgress(
         **{
             "Type": "AWS::EC2::SecurityGroupEgress",
             "Properties": {
-                "GroupId": "sg-1",
+                "GroupId": "sg-12341234",
                 "CidrIpv6": "fc00::/7",
                 "FromPort": 41,
                 "ToPort": 45,
@@ -54,7 +66,7 @@ def security_group_egress_ipv6_1():
 
 
 def test_security_group_egress(security_group_egress_ipv4_1):
-    assert security_group_egress_ipv4_1.Properties.GroupId == "sg-1"
+    assert security_group_egress_ipv4_1.Properties.GroupId == "sg-12341234"
     assert isinstance(security_group_egress_ipv4_1.Properties.FromPort, int)
 
 
@@ -66,5 +78,5 @@ def test_not_slash_zero4(security_group_egress_ipv4_2):
     assert security_group_egress_ipv4_2.ipv4_slash_zero() == False
 
 
-def test_not_slash_zero6(security_group_egress_ipv6_1):
-    assert security_group_egress_ipv6_1.ipv6_slash_zero() == False
+def test_not_slash_zero6(security_group_egress_ipv6):
+    assert security_group_egress_ipv6.ipv6_slash_zero() == False

--- a/tests/resources/test_security_group_egress.py
+++ b/tests/resources/test_security_group_egress.py
@@ -70,7 +70,7 @@ def test_ipv4_private_addr(ipv4, expected, security_group_egress_ipv4):
         ("FD00::/8", True),
         (None, False),
         (1, False),
-        ("2001:0db8:85a3:0000:0000:8a2e:0370:7334", False),
+        ("0001:0db8:85a3:0000:0000:8a2e:0370:7334", False),
     ],
 )
 def test_ipv6_private_addr(ipv6, expected, security_group_egress_ipv6):

--- a/tests/resources/test_security_group_egress.py
+++ b/tests/resources/test_security_group_egress.py
@@ -24,7 +24,7 @@ def security_group_egress_ipv4_1():
             "Type": "AWS::EC2::SecurityGroupEgress",
             "Properties": {
                 "GroupId": "sg-12341234",
-                "CidrIp": "0.0.0.0/0",
+                "CidrIp": "1.1.1.1/0",
                 "FromPort": 41,
                 "ToPort": 45,
                 "IpProtocol": "tcp",

--- a/tests/resources/test_security_group_ingress.py
+++ b/tests/resources/test_security_group_ingress.py
@@ -24,7 +24,7 @@ def security_group_ingress_ipv4_1():
             "Type": "AWS::EC2::SecurityGroupIngress",
             "Properties": {
                 "GroupId": "sg-12341234",
-                "CidrIp": "0.0.0.0/0",
+                "CidrIp": "1.1.1.1/0",
                 "FromPort": 46,
                 "ToPort": 46,
                 "IpProtocol": "tcp",

--- a/tests/resources/test_security_group_ingress.py
+++ b/tests/resources/test_security_group_ingress.py
@@ -22,7 +22,13 @@ def security_group_ingress_ipv4_1():
     return SecurityGroupIngress(
         **{
             "Type": "AWS::EC2::SecurityGroupIngress",
-            "Properties": {"GroupId": "sg-1", "CidrIp": "0.0.0.0/0", "FromPort": 46, "ToPort": 46, "IpProtocol": "tcp"},
+            "Properties": {
+                "GroupId": "sg-12341234",
+                "CidrIp": "0.0.0.0/0",
+                "FromPort": 46,
+                "ToPort": 46,
+                "IpProtocol": "tcp",
+            },
         }
     )
 
@@ -32,19 +38,25 @@ def security_group_ingress_ipv4_2():
     return SecurityGroupIngress(
         **{
             "Type": "AWS::EC2::SecurityGroupIngress",
-            "Properties": {"GroupId": "sg-2", "CidrIp": "127.0.0.0", "FromPort": 46, "ToPort": 46, "IpProtocol": "tcp"},
+            "Properties": {
+                "GroupId": "sg-2345",
+                "CidrIp": "127.0.0.0",
+                "FromPort": 46,
+                "ToPort": 46,
+                "IpProtocol": "tcp",
+            },
         }
     )
 
 
 @pytest.fixture()
-def security_group_ingress_ipv6_1():
+def security_group_ingress_ipv6():
     return SecurityGroupIngress(
         **{
             "Type": "AWS::EC2::SecurityGroupIngress",
             "Properties": {
                 "GroupId": "sg-12341234",
-                "CidrIpv6": "fc00::/7",
+                "CidrIpv6": "2001:0db8:0000:0000:0000:ff00:0042:8329",
                 "FromPort": 46,
                 "ToPort": 46,
                 "IpProtocol": "tcp",
@@ -54,7 +66,7 @@ def security_group_ingress_ipv6_1():
 
 
 def test_security_group_ingress(security_group_ingress_ipv4_1):
-    assert security_group_ingress_ipv4_1.Properties.GroupId == "sg-1"
+    assert security_group_ingress_ipv4_1.Properties.GroupId == "sg-12341234"
     assert isinstance(security_group_ingress_ipv4_1.Properties.FromPort, int)
 
 
@@ -66,5 +78,5 @@ def test_not_slash_zero4(security_group_ingress_ipv4_2):
     assert security_group_ingress_ipv4_2.ipv4_slash_zero() == False
 
 
-def test_not_slash_zero6(security_group_ingress_ipv6_1):
-    assert security_group_ingress_ipv6_1.ipv6_slash_zero() == False
+def test_not_slash_zero6(security_group_ingress_ipv6):
+    assert security_group_ingress_ipv6.ipv6_slash_zero() == False

--- a/tests/resources/test_security_group_ingress.py
+++ b/tests/resources/test_security_group_ingress.py
@@ -18,47 +18,61 @@ from pycfmodel.model.resources.security_group_ingress import SecurityGroupIngres
 
 
 @pytest.fixture()
-def security_group_ingress_1():
+def security_group_ingress_ipv4():
     return SecurityGroupIngress(
         **{
             "Type": "AWS::EC2::SecurityGroupIngress",
-            "Properties": {
-                "GroupId": "sg-12341234",
-                "CidrIp": "0.0.0.0/0",
-                "FromPort": 46,
-                "ToPort": 46,
-                "IpProtocol": "tcp",
-            },
+            "Properties": {"GroupId": "sg-12341234", "CidrIp": "", "FromPort": 46, "ToPort": 46, "IpProtocol": "tcp"},
         }
     )
 
 
 @pytest.fixture()
-def security_group_ingress_2():
+def security_group_ingress_ipv6():
     return SecurityGroupIngress(
         **{
             "Type": "AWS::EC2::SecurityGroupIngress",
-            "Properties": {
-                "GroupId": "sg-12341234",
-                "CidrIpv6": "2001:0db8:0000:0000:0000:ff00:0042:8329/0",
-                "FromPort": 46,
-                "ToPort": 46,
-                "IpProtocol": "tcp",
-            },
+            "Properties": {"GroupId": "sg-12341234", "CidrIpv6": "", "FromPort": 46, "ToPort": 46, "IpProtocol": "tcp"},
         }
     )
 
 
-def test_security_group_ingress(security_group_ingress_1):
-    assert security_group_ingress_1.Properties.GroupId == "sg-12341234"
-    assert isinstance(security_group_ingress_1.Properties.FromPort, int)
+def test_security_group_ingress(security_group_ingress_ipv4):
+    assert security_group_ingress_ipv4.Properties.GroupId == "sg-12341234"
+    assert isinstance(security_group_ingress_ipv4.Properties.FromPort, int)
 
 
-def test_slash_zero4(security_group_ingress_1, security_group_ingress_2):
-    assert security_group_ingress_1.ipv4_slash_zero()
-    assert not security_group_ingress_2.ipv4_slash_zero()
+@pytest.mark.parametrize("ipv4, expected", [("1.1.1.1/0", True), (None, False), (1, False), ("172.16.0.0/12", False)])
+def test_slash_zero4(ipv4, expected, security_group_ingress_ipv4):
+    security_group_ingress_ipv4.Properties.CidrIp = ipv4
+    assert security_group_ingress_ipv4.ipv4_slash_zero() == expected
 
 
-def test_slash_zero6(security_group_ingress_1, security_group_ingress_2):
-    assert not security_group_ingress_1.ipv6_slash_zero()
-    assert security_group_ingress_2.ipv6_slash_zero()
+@pytest.mark.parametrize("ipv6, expected", [("1.1.1.1/0", True), (None, False), (1, False), ("172.16.0.0/12", False)])
+def test_slash_zero6(ipv6, expected, security_group_ingress_ipv6):
+    security_group_ingress_ipv6.Properties.CidrIpv6 = ipv6
+    assert security_group_ingress_ipv6.ipv6_slash_zero() == expected
+
+
+@pytest.mark.parametrize(
+    "ipv4, expected", [("1.1.1.1/0", False), ("10.0.0.0/8", True), (None, False), (1, False), ("172.0.0.0/8", False)]
+)
+def test_ipv4_private_addr(ipv4, expected, security_group_ingress_ipv4):
+    security_group_ingress_ipv4.Properties.CidrIp = ipv4
+    assert security_group_ingress_ipv4.ipv4_private_addr() == expected
+
+
+@pytest.mark.parametrize(
+    "ipv6, expected",
+    [
+        ("1.1.1.1/0", False),
+        ("fc00::/7", True),
+        ("FD00::/8", True),
+        (None, False),
+        (1, False),
+        ("2001:0db8:85a3:0000:0000:8a2e:0370:7334", False),
+    ],
+)
+def test_ipv6_private_addr(ipv6, expected, security_group_ingress_ipv6):
+    security_group_ingress_ipv6.Properties.CidrIpv6 = ipv6
+    assert security_group_ingress_ipv6.ipv6_private_addr() == expected

--- a/tests/resources/test_security_group_ingress.py
+++ b/tests/resources/test_security_group_ingress.py
@@ -18,61 +18,53 @@ from pycfmodel.model.resources.security_group_ingress import SecurityGroupIngres
 
 
 @pytest.fixture()
-def security_group_ingress_ipv4():
+def security_group_ingress_ipv4_1():
     return SecurityGroupIngress(
         **{
             "Type": "AWS::EC2::SecurityGroupIngress",
-            "Properties": {"GroupId": "sg-12341234", "CidrIp": "", "FromPort": 46, "ToPort": 46, "IpProtocol": "tcp"},
+            "Properties": {"GroupId": "sg-1", "CidrIp": "0.0.0.0/0", "FromPort": 46, "ToPort": 46, "IpProtocol": "tcp"},
         }
     )
 
 
 @pytest.fixture()
-def security_group_ingress_ipv6():
+def security_group_ingress_ipv4_2():
     return SecurityGroupIngress(
         **{
             "Type": "AWS::EC2::SecurityGroupIngress",
-            "Properties": {"GroupId": "sg-12341234", "CidrIpv6": "", "FromPort": 46, "ToPort": 46, "IpProtocol": "tcp"},
+            "Properties": {"GroupId": "sg-2", "CidrIp": "127.0.0.0", "FromPort": 46, "ToPort": 46, "IpProtocol": "tcp"},
         }
     )
 
 
-def test_security_group_ingress(security_group_ingress_ipv4):
-    assert security_group_ingress_ipv4.Properties.GroupId == "sg-12341234"
-    assert isinstance(security_group_ingress_ipv4.Properties.FromPort, int)
+@pytest.fixture()
+def security_group_ingress_ipv6_1():
+    return SecurityGroupIngress(
+        **{
+            "Type": "AWS::EC2::SecurityGroupIngress",
+            "Properties": {
+                "GroupId": "sg-12341234",
+                "CidrIpv6": "fc00::/7",
+                "FromPort": 46,
+                "ToPort": 46,
+                "IpProtocol": "tcp",
+            },
+        }
+    )
 
 
-@pytest.mark.parametrize("ipv4, expected", [("1.1.1.1/0", True), (None, False), (1, False), ("172.16.0.0/12", False)])
-def test_slash_zero4(ipv4, expected, security_group_ingress_ipv4):
-    security_group_ingress_ipv4.Properties.CidrIp = ipv4
-    assert security_group_ingress_ipv4.ipv4_slash_zero() == expected
+def test_security_group_ingress(security_group_ingress_ipv4_1):
+    assert security_group_ingress_ipv4_1.Properties.GroupId == "sg-1"
+    assert isinstance(security_group_ingress_ipv4_1.Properties.FromPort, int)
 
 
-@pytest.mark.parametrize("ipv6, expected", [("1.1.1.1/0", True), (None, False), (1, False), ("172.16.0.0/12", False)])
-def test_slash_zero6(ipv6, expected, security_group_ingress_ipv6):
-    security_group_ingress_ipv6.Properties.CidrIpv6 = ipv6
-    assert security_group_ingress_ipv6.ipv6_slash_zero() == expected
+def test_slash_zero4(security_group_ingress_ipv4_1):
+    assert security_group_ingress_ipv4_1.ipv4_slash_zero() == True
 
 
-@pytest.mark.parametrize(
-    "ipv4, expected", [("1.1.1.1/0", False), ("10.0.0.0/8", True), (None, False), (1, False), ("172.0.0.0/8", False)]
-)
-def test_ipv4_private_addr(ipv4, expected, security_group_ingress_ipv4):
-    security_group_ingress_ipv4.Properties.CidrIp = ipv4
-    assert security_group_ingress_ipv4.ipv4_private_addr() == expected
+def test_not_slash_zero4(security_group_ingress_ipv4_2):
+    assert security_group_ingress_ipv4_2.ipv4_slash_zero() == False
 
 
-@pytest.mark.parametrize(
-    "ipv6, expected",
-    [
-        ("1.1.1.1/0", False),
-        ("fc00::/7", True),
-        ("FD00::/8", True),
-        (None, False),
-        (1, False),
-        ("0001:0db8:85a3:0000:0000:8a2e:0370:7334", False),
-    ],
-)
-def test_ipv6_private_addr(ipv6, expected, security_group_ingress_ipv6):
-    security_group_ingress_ipv6.Properties.CidrIpv6 = ipv6
-    assert security_group_ingress_ipv6.ipv6_private_addr() == expected
+def test_not_slash_zero6(security_group_ingress_ipv6_1):
+    assert security_group_ingress_ipv6_1.ipv6_slash_zero() == False

--- a/tests/resources/test_security_group_ingress.py
+++ b/tests/resources/test_security_group_ingress.py
@@ -70,7 +70,7 @@ def test_ipv4_private_addr(ipv4, expected, security_group_ingress_ipv4):
         ("FD00::/8", True),
         (None, False),
         (1, False),
-        ("2001:0db8:85a3:0000:0000:8a2e:0370:7334", False),
+        ("0001:0db8:85a3:0000:0000:8a2e:0370:7334", False),
     ],
 )
 def test_ipv6_private_addr(ipv6, expected, security_group_ingress_ipv6):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -467,13 +467,12 @@ def test_resolve_scenario_3():
             }
         },
     }
-    model = parse(template).resolve(extra_params={"IPValueIngress": "10.0.0.0/8", "IPValueEgress": "127.0.0.1"})
+    model = parse(template).resolve(extra_params={"IPValueIngress": "1.1.1.1/16", "IPValueEgress": "127.0.0.1"})
     assert (
         model.Resources["InstanceSecurityGroup"].Properties.SecurityGroupIngress[0].CidrIp.with_netmask
-        == "10.0.0.0/255.0.0.0"
+        == "1.1.0.0/255.255.0.0"
     )
-    assert model.Resources["InstanceSecurityGroup"].Properties.SecurityGroupIngress[0].CidrIp.is_private
-    assert not model.Resources["InstanceSecurityGroup"].Properties.SecurityGroupIngress[0].CidrIp.is_global
+    assert not model.Resources["InstanceSecurityGroup"].Properties.SecurityGroupIngress[0].CidrIp.is_private
     assert (
         model.Resources["InstanceSecurityGroup"].Properties.SecurityGroupEgress[0].CidrIp.with_netmask
         == "127.0.0.1/255.255.255.255"


### PR DESCRIPTION
This PR adds more accurate typing for the `CidrIp` and `CidrIpv6` fields that are contained within a Security Group model. 

Some tests were updated to reflect that Pydantic will now flag up invalid IP Network values passed to it.