### PR TITLE
FIX: Default value for AccessPolicies should be an empty list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 0.13.1 - [2022-01-18]
+### Fixes
+- Changed `AccessPolices` default value to empty list for, `ESDomain` and `OpenSearchDomain` resources.
+
 ## 0.13.0 - [2022-01-14]
 ### Additions
 - Added `ESDomain` resource.

--- a/pycfmodel/model/resources/es_domain.py
+++ b/pycfmodel/model/resources/es_domain.py
@@ -30,7 +30,7 @@ class ESDomainProperties(CustomModel):
     More info at [AWS Docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticsearch-domain.html)
     """
 
-    AccessPolicies: Optional[Resolvable[PolicyDocument]] = None
+    AccessPolicies: Optional[Resolvable[PolicyDocument]] = []
     AdvancedOptions: Optional[ResolvableDict] = None
     AdvancedSecurityOptions: Optional[ResolvableDict] = None
     CognitoOptions: Optional[ResolvableDict] = None

--- a/pycfmodel/model/resources/opensearch_domain.py
+++ b/pycfmodel/model/resources/opensearch_domain.py
@@ -30,7 +30,7 @@ class OpenSearchDomainProperties(CustomModel):
     More info at [AWS Docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opensearchservice-domain.html)
     """
 
-    AccessPolicies: Optional[Resolvable[PolicyDocument]] = None
+    AccessPolicies: Optional[Resolvable[PolicyDocument]] = []
     AdvancedOptions: Optional[ResolvableDict] = None
     AdvancedSecurityOptions: Optional[ResolvableDict] = None
     ClusterConfig: Optional[ResolvableDict] = None

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ docs_requires = ["AutoMacDoc==0.3", "mkdocs-material==4.6.3", "mkdocs==1.1", "mk
 
 setup(
     name="pycfmodel",
-    version="0.13.0",
+    version="0.13.1",
     description="A python model for CloudFormation scripts",
     author="Skyscanner Product Security",
     author_email="security@skyscanner.net",

--- a/tests/resources/test_es_domain.py
+++ b/tests/resources/test_es_domain.py
@@ -64,7 +64,7 @@ def valid_es_domain_from_aws_documentation_examples():
 
 def test_valid_empty_es_domain_resource_can_be_built(valid_empty_es_domain):
     assert valid_empty_es_domain.Type == "AWS::Elasticsearch::Domain"
-    assert valid_empty_es_domain.Properties.AccessPolicies is None
+    assert valid_empty_es_domain.Properties.AccessPolicies == []
     assert valid_empty_es_domain.Properties.AdvancedOptions is None
     assert valid_empty_es_domain.Properties.AdvancedSecurityOptions is None
     assert valid_empty_es_domain.Properties.CognitoOptions is None

--- a/tests/resources/test_opensearch_domain.py
+++ b/tests/resources/test_opensearch_domain.py
@@ -67,7 +67,7 @@ def valid_opensearch_domain_from_aws_documentation_examples():
 
 def test_valid_empty_opensearch_domain_resource_can_be_built(valid_empty_opensearch_domain):
     assert valid_empty_opensearch_domain.Type == "AWS::OpenSearchService::Domain"
-    assert valid_empty_opensearch_domain.Properties.AccessPolicies is None
+    assert valid_empty_opensearch_domain.Properties.AccessPolicies == []
     assert valid_empty_opensearch_domain.Properties.AdvancedOptions is None
     assert valid_empty_opensearch_domain.Properties.AdvancedSecurityOptions is None
     assert valid_empty_opensearch_domain.Properties.ClusterConfig is None


### PR DESCRIPTION
Default value for `AccessPolicies` should be an empty list.
If not, the rules `ElasticsearchDomainCrossAccountTrustRule` and `OpenSearchDomainCrossAccountTrustRule` of cfripper will fail since they won't be able to iterate over a `None`.