### PR TITLE
Add release drafter workflow

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -26,3 +26,7 @@ jobs:
       - run: make lint
 
       - run: make coverage
+        if: github.ref != 'refs/heads/master'
+
+      - run: make coverage-master
+        if: github.ref == 'refs/heads/master'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,32 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,12 @@ coverage:
 	coverage xml -i -o build/coverage.xml
 	coverage html
 
+coverage-master:
+	coverage run --source=pycfmodel --branch -m pytest tests/ --junitxml=build/test.xml -v -m "not actions"
+	coverage report
+	coverage xml -i -o build/coverage.xml
+	coverage html
+
 test: lint unit
 
 test-docs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,8 @@ skip-magic-trailing-comma = false
 
 # Like Black, automatically detect the appropriate line ending.
 line-ending = "auto"
+
+[tool.pytest.ini_options]
+markers = [
+    "actions: marks tests that checks the full list of IAM actions (deselect with '-m \"not actions\"')",
+]

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,10 +1,12 @@
 import json
 
 import httpx
+import pytest
 
 from pycfmodel.cloudformation_actions import CLOUDFORMATION_ACTIONS
 
 
+@pytest.mark.actions
 def test_cloudformation_actions():
     response = httpx.get("https://awspolicygen.s3.amazonaws.com/js/policies.js")
     response.raise_for_status()


### PR DESCRIPTION
- Add release drafter
- Run the test to check the full list of actions in all branches but master. The reason behind this is to avoid having broken builds in master as it is not a critical test when merging