### PR TITLE
SDPLAT-26671: use GH_APP for GitHub REST API

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
@@ -56,7 +58,7 @@ jobs:
       #   https://support.github.com/ticket/enterprise/3427/3214517
       - name: Prepare CodeQL Results
         run: |
-          echo "SARIF_RESULTS=$(gzip -c ../results/go.sarif | base64 -w0)" >> $GITHUB_ENV
+          echo "SARIF_RESULTS=$(gzip -c ../results/${{ matrix.language }}.sarif | base64 -w0)" >> $GITHUB_ENV
 
       - name: Upload CodeQL Results
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,6 @@ jobs:
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"
-        with:
           token: ${{ steps.app-token.outputs.token }}
           upload: never
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,11 +26,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3
@@ -39,3 +46,24 @@ jobs:
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          upload: never
+
+      # Workaround for parallel GitHub bugs
+      # * Can't use GHA token with IP allowlisting
+      #   https://docs.github.com/en/enterprise-cloud@latest/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-allowed-ip-addresses-for-your-organization#using-github-actions-with-an-ip-allow-list
+      # * Can't use codeql-action/analyze with custom token
+      #   https://support.github.com/ticket/enterprise/3427/3214517
+      - name: Prepare CodeQL Results
+        run: |
+          echo "SARIF_RESULTS=$(gzip -c ../results/go.sarif | base64 -w0)" >> $GITHUB_ENV
+
+      - name: Upload CodeQL Results
+        run: |
+          curl --fail-with-body \
+            -X POST \
+            -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{"commit_sha": "${{ github.sha }}", "ref": "${{ github.ref }}", "sarif": "${{ env.SARIF_RESULTS }}"}' \
+            https://api.github.com/repos/${{ github.repository }}/code-scanning/sarifs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,11 +60,15 @@ jobs:
         run: |
           echo "SARIF_RESULTS=$(gzip -c ../results/${{ matrix.language }}.sarif | base64 -w0)" >> $GITHUB_ENV
 
+      - name: Prepare CodeQL Upload
+        run: |
+          echo '{"commit_sha": "${{ github.sha }}", "ref": "${{ github.ref }}", "sarif": "${{ env.SARIF_RESULTS }}"}' > ./codeql-upload.json
+
       - name: Upload CodeQL Results
         run: |
           curl --fail-with-body \
             -X POST \
             -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
             -H "Accept: application/vnd.github.v3+json" \
-            -d '{"commit_sha": "${{ github.sha }}", "ref": "${{ github.ref }}", "sarif": "${{ env.SARIF_RESULTS }}"}' \
+            --data "@codeql-upload.json" \
             https://api.github.com/repos/${{ github.repository }}/code-scanning/sarifs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,13 +56,17 @@ jobs:
       #   https://docs.github.com/en/enterprise-cloud@latest/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-allowed-ip-addresses-for-your-organization#using-github-actions-with-an-ip-allow-list
       # * Can't use codeql-action/analyze with custom token
       #   https://support.github.com/ticket/enterprise/3427/3214517
-      - name: Prepare CodeQL Results
+      - name: Prepare for CodeQL Upload
         run: |
-          echo "SARIF_RESULTS=$(gzip -c ../results/${{ matrix.language }}.sarif | base64 -w0)" >> $GITHUB_ENV
+          echo '{"commit_sha": "${{ github.sha }}", "ref": "${{ github.ref }}"}' > ./codeql-upload.json
 
-      - name: Prepare CodeQL Upload
+      - name: Gzip CodeQL SARIF Result
         run: |
-          echo '{"commit_sha": "${{ github.sha }}", "ref": "${{ github.ref }}", "sarif": "${{ env.SARIF_RESULTS }}"}' > ./codeql-upload.json
+          gzip -c ../results/${{ matrix.language }}.sarif | base64 -w0 > codeql-results.sarif.gz.base64
+    
+      - name: Staple SARIF result to CodeQL upload
+        run: |
+          jq --rawfile sarif codeql-results.sarif.gz.base64 '.sarif = $sarif' codeql-upload.json > codeql-upload-with-sarif.json
 
       - name: Upload CodeQL Results
         run: |
@@ -70,5 +74,5 @@ jobs:
             -X POST \
             -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
             -H "Accept: application/vnd.github.v3+json" \
-            --data "@codeql-upload.json" \
+            --data "@codeql-upload-with-sarif.json" \
             https://api.github.com/repos/${{ github.repository }}/code-scanning/sarifs

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -27,6 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+
       - uses: release-drafter/release-drafter@v6
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change. -->

Use a GitHub App for access to the GitHub REST API as a workaround for [limitations with IP allowlisting](https://docs.github.com/en/enterprise-cloud@latest/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-allowed-ip-addresses-for-your-organization#using-github-actions-with-an-ip-allow-list).


## Checklist

- [x] I have updated the CHANGELOG.md
- [x] I have updated the setup.py

(not applicable / no functionality changes)