### PR TITLE
Decommission the CHANGELOG.md file

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,5 +5,4 @@
 
 ## Checklist
 
-- [ ] I have updated the CHANGELOG.md
 - [ ] I have updated the pyproject.toml

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,6 +13,9 @@ version-resolver:
     labels:
       - 'patch'
   default: patch
+exclude-labels:
+  - 'skip-changelog'
+  - 'dependencies'
 template: |
   ## Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+> ### This file is no longer used to track changes.
+> ### Please check the [releases](https://github.com/Skyscanner/pycfmodel/releases) page of this repo for future changelog information 
+
+
 # Change Log
 All notable changes to this project will be documented in this file.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,10 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/Skyscanner/pycfmodel"
+Repository = "https://github.com/Skyscanner/pycfmodel"
+"Bug Tracker" = "https://github.com/Skyscanner/pycfmodel/issues"
+Documentation = "https://pycfmodel.readthedocs.io"
+Changelog = "https://github.com/Skyscanner/pycfmodel/releases"
 
 [[project.authors]]
 name = "Skyscanner Security"


### PR DESCRIPTION
# Description

Decommission the CHANGELOG.md file in favour of the releases done in GitHub.
By:
1. Removing the check from the PR
2. Adding a "warning section" in the Changelog to redirect to the releases
3. Adding project urls to the package, which the changelog points to the releases

Also, excluding bump PRs for dependencies in the releases.


## Checklist

- [x] I have updated the pyproject.toml
